### PR TITLE
Fix search a for element in shadow context

### DIFF
--- a/index.js
+++ b/index.js
@@ -218,7 +218,7 @@ class MarkdownToolbarElement extends HTMLElement {
   get field(): ?HTMLTextAreaElement {
     const id = this.getAttribute('for')
     if (!id) return
-    const field = document.getElementById(id)
+    const field = this.getRootNode().getElementById(id)
     return field instanceof HTMLTextAreaElement ? field : null
   }
 }


### PR DESCRIPTION
If markdown-toolbar-element and textarea are located in a shadow context, the element can't find the textarea.